### PR TITLE
feat: add `campaignId` to campaign_insights stream

### DIFF
--- a/source_sosha/schemas/campaign_insights.json
+++ b/source_sosha/schemas/campaign_insights.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+      "campaignId": {
+        "type": ["string"]
+      },
       "numberOfClicksByPlatform": {
         "type": ["string"]
       },


### PR DESCRIPTION
This change is already pushed to Dockerhub in image tag 0.0.9! Already updated the source version in prod Airbyte and it seems to work as intended. (Can't update in dev yet because dev Airbyte is having a big sad, but will update there as well when possible.)